### PR TITLE
add css reads questions of session 1 dated 02-01-2022

### DIFF
--- a/dorm-room/02-01-2022.md
+++ b/dorm-room/02-01-2022.md
@@ -1,0 +1,25 @@
+### CSS Reads
+
+**Session Timings:** 02-01-2022 - 11:00AM - 01:00PM
+
+1. Extrinsic vs intrinsic sizing with an image - 
+    1. Ex - [https://codepen.io/web-dot-dev/embed/wvgwOJV?height=650&theme-id=light&default-tab=result&editable=true#result-box](https://codepen.io/web-dot-dev/embed/wvgwOJV?height=650&theme-id=light&default-tab=result&editable=true#result-box) 
+2. Why is inline scroll bar used? why only chaging padding of the box?
+
+**Skipped Topics:**
+
+1. Regex attribute selectors - CSS.
+2. Combinators - Next sibling combinator
+
+**Topics covered:**
+1. Box Model.
+2. Selectors.
+3. The cascade.
+
+**Topics That would be covered in next session:**
+
+4. Specificity.
+5. Inheritance.
+6. Color
+
+**Next session:** 03-01-2022 09:00PM.


### PR DESCRIPTION
Added questions to be asked on 4th of jan css event. 
These questions are from session 1 of css reads which was held on 02-01-2022.
Also added topics covered and to be covered in next session. 